### PR TITLE
Compatibility with Ruby 1.9.3

### DIFF
--- a/lib/backticks/cli.rb
+++ b/lib/backticks/cli.rb
@@ -70,7 +70,7 @@ module Backticks
       # Unix-like parameters.
       #
       # @return [Array] list of String command-line options
-      def self.options(**opts)
+      def self.options(opts={})
         flags = []
 
         # Transform opts into golang flags-style command line parameters;

--- a/lib/backticks/runner.rb
+++ b/lib/backticks/runner.rb
@@ -33,10 +33,16 @@ module Backticks
 
     # Create an instance of Runner.
     # @param [#parameters] cli object used to convert Ruby method parameters into command-line parameters
-    def initialize(buffered:false, cli:Backticks::CLI::Getopt, interactive:false)
-      @buffered = buffered
-      @cli = cli
-      @interactive = interactive
+    def initialize(options={})
+      options = {
+        :buffered => false,
+        :cli => Backticks::CLI::Getopt,
+        :interactive => false,
+      }.merge(options)
+
+      @buffered = options[:buffered]
+      @cli = options[:cli]
+      @interactive = options[:interactive]
     end
 
     # Run a command whose parameters are expressed using some Rubyish sugar.

--- a/spec/backticks_spec.rb
+++ b/spec/backticks_spec.rb
@@ -4,8 +4,4 @@ describe Backticks do
   it 'has a version number' do
     expect(Backticks::VERSION).not_to be nil
   end
-
-  it 'does something useful' do
-    expect(false).to eq(true)
-  end
 end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe Backticks::CLI do
+  describe Backticks::CLI::Getopt do
+    describe "self.options" do
+      it "converts hash arguments" do
+        expect(Backticks::CLI::Getopt.options(:X => "V")).to eq(["-X", "V"])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Two changes due to Ruby 1.9.3 not having support for keyword arguments.