### PR TITLE
Gracefully handling closed or empty STDIN.

### DIFF
--- a/lib/backticks/command.rb
+++ b/lib/backticks/command.rb
@@ -93,12 +93,12 @@ module Backticks
       # proxy STDIN to child's stdin
       if ready && ready.include?(STDIN)
         input = STDIN.readpartial(CHUNK) rescue nil
-        @captured_input << input
         if input
+          @captured_input << input
           @stdin.write(input)
         else
           # our own STDIN got closed; proxy this fact to the child
-          @stdin.close
+          @stdin.close unless @stdin.closed?
         end
       end
 

--- a/spec/backticks/command_spec.rb
+++ b/spec/backticks/command_spec.rb
@@ -7,5 +7,23 @@ describe Backticks::Command do
       expect {subject.join}.not_to raise_error
       expect(subject).to succeed
     end
+
+    context 'interactive' do
+      subject { Backticks::Runner.new(:interactive => true).command('ls') }
+
+      it 'gracefully handles empty STDIN' do
+        allow(IO).to receive(:select).and_return([[STDIN], nil, nil])
+        allow(STDIN).to receive(:readpartial).and_raise("Boom!")
+
+        expect { subject.join }.not_to raise_error
+      end
+
+      it 'gracefully handles closed STDIN' do
+        allow(IO).to receive(:select).and_return([[STDIN], nil, nil])
+        allow(STDIN).to receive(:readpartial).and_return(nil)
+
+        expect { subject.join }.not_to raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
Ran into some cases with interactive commands that caused Backticks to raise.