### PR TITLE
Using IO.pipe over PTY.open for STDIN.

### DIFF
--- a/lib/backticks/runner.rb
+++ b/lib/backticks/runner.rb
@@ -94,7 +94,7 @@ module Backticks
     private
     def run_unbuffered(argv)
       stdout, stdout_w = PTY.open
-      stdin_r, stdin = PTY.open
+      stdin_r, stdin = IO.pipe
       stderr, stderr_w = PTY.open
       pid = spawn(*argv, in: stdin_r, out: stdout_w, err: stderr_w)
       stdin_r.close


### PR DESCRIPTION
Sadly, I don't really know of a good way to write a test for this case, so I'll try to explain the issue we were seeing.

We're running a docker-compose command with `interactive => true` to display unbuffered output. This worked fine on a local machine in a terminal, but once it ran on a Jenkins machine, it produced the following error:
```
Traceback (most recent call last):
  File "<string>", line 3, in <module>
  File "/code/compose/cli/main.py", line 54, in main
  File "/code/compose/cli/docopt_command.py", line 23, in sys_dispatch
  File "/code/compose/cli/docopt_command.py", line 26, in dispatch
  File "/code/compose/cli/main.py", line 171, in perform_command
  File "/code/compose/cli/main.py", line 421, in run
  File "/code/compose/cli/main.py", line 655, in run_one_off_container
  File "/code/.tox/py27/lib/python2.7/site-packages/dockerpty/__init__.py", line 27, in start
  File "/code/.tox/py27/lib/python2.7/site-packages/dockerpty/pty.py", line 153, in start
  File "/code/.tox/py27/lib/python2.7/site-packages/dockerpty/pty.py", line 244, in _hijack_tty
  File "/code/.tox/py27/lib/python2.7/site-packages/dockerpty/io.py", line 378, in flush
OSError: [Errno 5] Input/output error
docker-compose returned -1
```
I ssh'd onto the Jenkins machine and ran the same command through Backticks and it worked. Jenkins must be doing something unexpected around I/O.

Eventually, we found this example in the Ruby documentation:
http://ruby-doc.org/stdlib-2.0.0/libdoc/pty/rdoc/PTY.html#module-PTY-label-Example

After modifying the stdin to use `IO.pipe` instead of `PTY.open`, everything seems to be working.