### PR TITLE
Fix warnings

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,4 +1,5 @@
 --format documentation
 --color
 --order random
+--warnings
 --require spec_helper

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,7 @@ rvm:
 - 2.0
 - 2.1
 - 2.2
+- 2.3
+- 2.4
 before_install: gem install bundler -v '~> 1.10'
 script: bundle exec rake spec

--- a/lib/backticks/command.rb
+++ b/lib/backticks/command.rb
@@ -43,6 +43,8 @@ module Backticks
       @stdout = stdout
       @stderr = stderr
       @interactive = !!interactive
+      @tap = nil
+      @status = nil
 
       @captured_input  = String.new.force_encoding(Encoding::BINARY)
       @captured_output = String.new.force_encoding(Encoding::BINARY)

--- a/lib/backticks/runner.rb
+++ b/lib/backticks/runner.rb
@@ -60,6 +60,7 @@ module Backticks
       }.merge(options)
 
       @cli = options[:cli]
+      @chdir = nil
       self.buffered = options[:buffered]
       self.interactive = options[:interactive]
     end

--- a/spec/backticks/runner_spec.rb
+++ b/spec/backticks/runner_spec.rb
@@ -18,13 +18,13 @@ describe Backticks::Runner do
       it 'spawns with new pwd' do
         subject.chdir='/tmp/banana'
         expect(subject).to receive(:spawn).with('ls', hash_including(chdir:'/tmp/banana'))
-        cmd = subject.run('ls')
+        subject.run('ls')
       end
 
       it 'defaults to PWD' do
         subject.chdir=nil
         expect(subject).to receive(:spawn).with('ls', hash_including(chdir:Dir.pwd))
-        cmd = subject.run('ls')
+        subject.run('ls')
       end
     end
 


### PR DESCRIPTION
Fixes two ruby warnings:

`warning: instance variable @something not initialized`

and

`assigned but unused variable something`